### PR TITLE
Changed the path keyword 'property' into 'customer'.

### DIFF
--- a/customer-information-api/V1/Controllers/CustomerInformationController.cs
+++ b/customer-information-api/V1/Controllers/CustomerInformationController.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace customer_information_api.V1.Controllers
 {
     [ApiVersion("1")]
-    [Route("api/v1/property")]
+    [Route("api/v1/customer")]
     [ApiController]
     [Produces("application/json")]
     public class CustomerInformationController : BaseController


### PR DESCRIPTION
As agreed by the team, the endpoint will say: "customer" rather than "customerInformation".